### PR TITLE
KOHA-1673 Handle Reregistration

### DIFF
--- a/app/models/student_participation.rb
+++ b/app/models/student_participation.rb
@@ -17,6 +17,8 @@ class StudentParticipation
       process_admission
     elsif @participation_type == "Registration"
       process_registration
+    elsif @participation_type == "Reregistration"
+      process_registration
     end
   end
 


### PR DESCRIPTION
A Registration message is used to create or update student data in Koha.
Sometimes there is a near identical version called Reregistration that should
be handled the exact same way.